### PR TITLE
feat: Implement leave family functionality

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -34,24 +34,47 @@ service cloud.firestore {
       // Permite ATUALIZAR um household se:
       // 1. O solicitante é o proprietário.
       // 2. OU o solicitante está aceitando seu próprio convite sob condições específicas.
+      // 3. OU o solicitante (não proprietário) está saindo da família.
       allow update: if request.auth != null &&
                      (
-                       // Proprietário pode fazer qualquer atualização
+                       // Condition 1: Proprietário pode fazer qualquer atualização
                        resource.data.ownerId == request.auth.uid ||
-                       // Usuário aceitando seu próprio convite
+                       
+                       // Condition 2: Usuário aceitando seu próprio convite
                        (
                          request.resource.data.members[request.auth.uid] != null && // Cond1: Adding self to members
                          !(request.auth.uid in resource.data.members) &&            // Cond2: Not a previous member
-                         // New Cond3: Verifies one invite was removed from pendingInvites
+                         // Cond3: Verifies one invite was removed from pendingInvites
                          (
                            resource.data.pendingInvites != null &&
                            request.resource.data.pendingInvites != null &&
+                           // Ensure a pending invite for the user was actually removed by checking the key
+                           // This is a simplified check; a more robust check would verify the specific user's invite was removed.
                            request.resource.data.pendingInvites.keys().size() == resource.data.pendingInvites.keys().size() - 1
                          ) &&
-                         // New Cond4: Ensure other critical non-map fields are unchanged by the invitee
+                         // Cond4: Ensure other critical non-map fields are unchanged by the invitee
                          request.resource.data.ownerId == resource.data.ownerId &&
-                         request.resource.data.name == resource.data.name // Assuming 'name' is the field for household name
+                         request.resource.data.name == resource.data.name 
                          // Add other top-level non-map fields here if they exist and must be immutable by invitee
+                       ) ||
+
+                       // Condition 3: Usuário saindo da família
+                       (
+                         request.auth.uid in resource.data.members && // User is currently a member
+                         resource.data.ownerId != request.auth.uid && // User is NOT the owner
+                         request.resource.data.members[request.auth.uid] == null && // User is removing themselves from members map
+                         resource.data.members[request.auth.uid] != null && // User was in members map before this specific update
+                         request.resource.data.members.keys().size() == resource.data.members.keys().size() - 1 && // Size of members map decreases by exactly 1
+                         // Ensure other critical fields are unchanged
+                         request.resource.data.ownerId == resource.data.ownerId &&
+                         request.resource.data.name == resource.data.name &&
+                         // Ensure pendingInvites map is unchanged by this operation
+                         (
+                           (resource.data.pendingInvites == null && request.resource.data.pendingInvites == null) ||
+                           (resource.data.pendingInvites != null && request.resource.data.pendingInvites != null &&
+                            resource.data.pendingInvites.keys().size() == request.resource.data.pendingInvites.keys().size())
+                         )
+                         // Add other top-level non-map fields here if they exist and must be immutable
                        )
                      );
 

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
                      <h4 class="text-md font-semibold text-slate-700 dark:text-slate-300 mb-2">Membros Atuais:</h4>
                      <ul id="household-members-list" class="list-disc list-inside text-slate-600 dark:text-slate-400 pl-2 space-y-1"></ul>
                 </div>
+                <button id="leave-family-btn" class="hidden bg-rose-500 text-white font-semibold py-2 px-4 rounded-lg hover:bg-rose-600 dark:hover:bg-rose-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] shadow-md dark:shadow-black/30 mt-4 w-full sm:w-auto">Sair da Família</button>
             </div>
              <div id="accept-invite-section" class="mt-6 pt-6 border-t border-slate-200 dark:border-slate-600 hidden">
                 <h3 class="text-xl font-semibold text-slate-800 dark:text-slate-200 mb-3">Convites Pendentes</h3>
@@ -390,6 +391,7 @@
             const householdMembersList = document.getElementById('household-members-list');
             const manageFamilyBtn = document.getElementById('manage-family-btn'); 
             const backToAppBtn = document.getElementById('back-to-app-btn');
+            const leaveFamilyBtn = document.getElementById('leave-family-btn');
 
 
             const acceptInviteSection = document.getElementById('accept-invite-section');
@@ -511,6 +513,54 @@
                     case 'auth/internal-error': return 'Ocorreu um erro interno no sistema de autenticação. Tente novamente.';
                     case 'auth/argument-error': return 'Erro de argumento na função de autenticação. Verifique o console.';
                     default: return 'Ocorreu um erro de autenticação. Tente novamente. Código: ' + errorCode;
+                }
+            }
+
+            async function leaveFamily() {
+                if (!userId || !activeHouseholdId) {
+                    alert("Erro: Usuário não logado ou família não selecionada.");
+                    return;
+                }
+
+                if (householdData && userId === householdData.ownerId) {
+                    alert("Você é o proprietário da família. Para sair, você precisa excluir a família ou transferir a propriedade.");
+                    return;
+                }
+
+                if (confirm("Tem certeza que deseja sair desta família? Esta ação não pode ser desfeita.")) {
+                    showScreen('loading');
+                    const householdDocRef = doc(db, "households", activeHouseholdId);
+                    const userDocRef = doc(db, "users", userId);
+
+                    try {
+                        await runTransaction(db, async (transaction) => {
+                            transaction.update(householdDocRef, {
+                                [`members.${userId}`]: deleteField()
+                            });
+                            transaction.update(userDocRef, {
+                                activeHouseholdId: null
+                            });
+                        });
+
+                        activeHouseholdId = null;
+                        householdData = null;
+                        
+                        if (typeof unsubscribeFirestore === 'function') {
+                            unsubscribeFirestore();
+                            unsubscribeFirestore = null;
+                        }
+                        transactions = [];
+                        populateMonthFilter(); // Clears and repopulates month filter
+                        updateDashboard(); // Clears charts and table
+
+                        populateManageHouseholdUI(); // Should hide leave button, show create/join
+                        showScreen('household'); 
+
+                    } catch (error) {
+                        console.error("Erro ao sair da família:", error);
+                        alert("Erro ao sair da família: " + error.message);
+                        showScreen('household'); // Or 'app' if the button could be there too
+                    }
                 }
             }
 
@@ -963,6 +1013,8 @@
             }
 
             function populateManageHouseholdUI() { 
+                const leaveFamilyBtn = document.getElementById('leave-family-btn'); // Get ref inside
+
                 if (householdData && activeHouseholdId) {
                     if(createHouseholdSection) createHouseholdSection.classList.add('hidden');
                     if(manageHouseholdSection) manageHouseholdSection.classList.remove('hidden');
@@ -979,9 +1031,22 @@
                         });
                     }
                     if(inviteMemberForm) inviteMemberForm.classList.toggle('hidden', userId !== householdData.ownerId);
+
+                    if (leaveFamilyBtn) {
+                        const isOwner = userId === householdData.ownerId;
+                        const isMember = householdData.members && householdData.members[userId];
+                        if (isMember && !isOwner) {
+                            leaveFamilyBtn.classList.remove('hidden');
+                        } else {
+                            leaveFamilyBtn.classList.add('hidden');
+                        }
+                    }
+
                 } else {
                     if(createHouseholdSection) createHouseholdSection.classList.remove('hidden');
                     if(manageHouseholdSection) manageHouseholdSection.classList.add('hidden');
+                    if(leaveFamilyBtn) leaveFamilyBtn.classList.add('hidden'); 
+                    
                     if (userId && userEmail) { 
                         checkAndDisplayInvites(userEmail, userId);
                     } else {
@@ -1011,6 +1076,7 @@
             });
             if(createHouseholdBtn) createHouseholdBtn.addEventListener('click', createHousehold);
             if(inviteMemberForm) inviteMemberForm.addEventListener('submit', handleInviteMember);
+            if(leaveFamilyBtn) leaveFamilyBtn.addEventListener('click', leaveFamily);
             if(monthFilter) monthFilter.addEventListener('change', (e) => { selectedMonthYear = e.target.value; updateDashboard(); });
             if(addTransactionBtn) addTransactionBtn.addEventListener('click', openModal);
             if(closeModalBtn) closeModalBtn.addEventListener('click', closeModal);


### PR DESCRIPTION
Adds a button allowing you to leave a family/group.

Key changes:
- Added a "Sair da Família" (Leave Family) button to the family management UI.
- Implemented the `leaveFamily()` JavaScript function to handle the logic:
    - Removes the user from the `members` map in the Firestore `households` document.
    - Sets the `activeHouseholdId` to `null` in the user's Firestore document.
    - Updates the UI to reflect the user no longer being in a family.
- The button is only visible to non-owner members of a family. Owners cannot use this button to leave; they must delete the family or transfer ownership (though these latter actions are not part of this change).
- Updated Firestore security rules for `/households/{householdId}` to:
    - Allow a member to update the document by removing themselves from the `members` map.
    - Ensure the owner cannot remove themselves via this mechanism.
    - Ensure other critical household data remains unchanged during this operation.