### PR TITLE
feat: Add CSS for smoother page transitions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,17 @@
         body { border-top: 16px solid #ffa100; }
       }
     </style>
+    <style>
+      /* CSS for page fade-out animation */
+      @keyframes fadeOutPage {
+        from { opacity: 1; }
+        to { opacity: 0; }
+      }
+      body.fade-out-on-navigate {
+        /* Adjust duration to be slightly less than JS timeout for navigation */
+        animation: fadeOutPage 0.4s ease-out forwards;
+      }
+    </style>
   </head>
   <body>
     <nav class="bg-gray-800 text-white p-4">

--- a/public/investimentos.html
+++ b/public/investimentos.html
@@ -6,8 +6,17 @@
     <title>Investimentos - Gestão de Lançamentos</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+      @keyframes fadeInPage {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+      body.fade-in-on-load {
+        animation: fadeInPage 0.5s ease-out forwards;
+      }
+    </style>
 </head>
-<body>
+<body class="fade-in-on-load">
     <h1 class="text-2xl font-bold p-4">Painel de Investimentos</h1> <!-- Changed Page Title -->
     <div id="investments-dashboard" class="p-4">
         <!-- Summary Cards Row -->


### PR DESCRIPTION
This commit introduces CSS animations to improve the visual transition experience when navigating between your main application page and the investments page.

Changes include:

1.  **`public/investimentos.html`:**
    *   Added CSS keyframes for a fade-in animation (`fadeInPage`).
    *   Applied a class (`fade-in-on-load`) to the `<body>` tag to trigger this animation when `investimentos.html` loads, making its appearance smoother.

2.  **`public/index.html`:**
    *   Added CSS keyframes for a fade-out animation (`fadeOutPage`) and a corresponding class (`body.fade-out-on-navigate`).
    *   These styles are intended to be used by JavaScript in the main application page. When navigating away from `index.html` (e.g., to the investments page), JavaScript can add the `fade-out-on-navigate` class to the body and use a short timeout before changing `window.location.href`. This provides a fade-out effect on the departing page. I've provided guidance for this JavaScript implementation to you separately.

These changes aim to make page navigation feel less abrupt. The actual triggering of the fade-out effect on the source page relies on you integrating the provided JavaScript snippet into your main application logic.