### PR TITLE
Refatorar botão de Investimentos para link em nova aba

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,9 +146,9 @@
                     <span class="text-lg">+</span>
                     <span>Adicionar</span>
                 </button>
-                <button id="investments-btn" class="bg-emerald-500 text-white font-semibold py-2 px-3 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-emerald-600 dark:hover:bg-emerald-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
+                <a id="investments-btn" href="public/investimentos.html" target="_blank" class="bg-emerald-500 text-white font-semibold py-2 px-3 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-emerald-600 dark:hover:bg-emerald-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
                     <span>💹</span> <span>Investimentos</span>
-                </button>
+                </a>
                 <button id="manage-family-btn" class="bg-teal-500 text-white font-semibold py-2 px-3 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-teal-600 dark:hover:bg-teal-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
                      <span>&#128106;</span> <span>Família</span>
                 </button>
@@ -1294,7 +1294,7 @@
             }
 
             // Event Listeners for Investments
-            if(investmentsBtn) investmentsBtn.addEventListener('click', () => showScreen('investments'));
+            // if(investmentsBtn) investmentsBtn.addEventListener('click', () => showScreen('investments'));
             if(backToAppFromInvestmentsBtn) backToAppFromInvestmentsBtn.addEventListener('click', () => showScreen('app'));
             if(addInvestmentAccountBtn) addInvestmentAccountBtn.addEventListener('click', openAddInvestmentAccountModal);
             if(closeAddInvestmentAccountModalBtn) closeAddInvestmentAccountModalBtn.addEventListener('click', closeAddInvestmentAccountModal);


### PR DESCRIPTION
- Alterei o botão 'Investimentos' na index.html para uma tag <a>.
- O link aponta para public/investimentos.html e abre em uma nova aba.
- O event listener JavaScript associado ao comportamento antigo do botão foi removido.
- A estilização foi mantida para consistência visual.

Esta alteração atende à sua solicitação de reestruturar o acesso à área de investimentos, tornando-o um link direto para uma página de gestão dedicada que abre em uma nova aba.