### PR TITLE
fix: Remove temporariamente a seção headers do firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,4 @@
-
-  {
+{
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
@@ -15,22 +14,6 @@
       {
         "source": "**",
         "destination": "/index.html"
-      }
-    ],
-    "headers": [
-      {
-        "source": "**",
- feat/investments-link-new-tab
-        "headers": [
-          {
-            "key": "Content-Security-Policy",
-            "value": "script-src 'self' https://cdn.tailwindcss.com https://www.gstatic.com https://cdn.jsdelivr.net https://fonts.googleapis.com https://fonts.gstatic.com 'unsafe-eval'; object-src 'none'; base-uri 'self';"
-          }
-        ]
-
-        "key": "Content-Security-Policy",
-        "value": "script-src 'self' https://cdn.tailwindcss.com https://www.gstatic.com https://cdn.jsdelivr.net https://fonts.googleapis.com https://fonts.gstatic.com 'unsafe-eval'; object-src 'none'; base-uri 'self';"
- main
       }
     ]
   }


### PR DESCRIPTION
Remove a configuração `hosting.headers` para diagnosticar problemas de deploy no Firebase Hosting. Esta é uma medida temporária para tentar fazer o site voltar a subir.

A configuração do Content Security Policy precisará ser revisitada após o deploy ser bem-sucedido.