### PR TITLE
style: Update header button styling and user info display

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,17 +142,17 @@
                 <div id="user-info" class="text-xs sm:text-sm text-slate-600 dark:text-slate-400 hidden order-first lg:order-none w-full lg:w-auto text-center lg:text-right mb-2 sm:mb-0 lg:mr-2"></div>
                 <select id="month-filter" class="bg-white dark:bg-slate-700 dark:text-slate-200 border border-slate-300 dark:border-slate-600 rounded-lg shadow-sm dark:shadow-black/30 py-2 px-3 text-sm focus:ring-2 focus:ring-sky-500 dark:focus:ring-sky-400 focus:outline-none w-full sm:w-auto sm:flex-shrink-0">
                 </select>
-                <button id="add-transaction-btn" class="bg-sky-600 text-white font-semibold py-2 px-3 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-sky-700 dark:hover:bg-sky-500 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
+                <button id="add-transaction-btn" class="bg-slate-500 text-white font-semibold py-2 px-4 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-slate-600 dark:bg-slate-600 dark:text-slate-200 dark:hover:bg-slate-500 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
                     <span class="text-lg">+</span>
                     <span>Adicionar</span>
                 </button>
-                <a id="investments-btn" href="public/investimentos.html" target="_blank" class="bg-emerald-500 text-white font-semibold py-2 px-3 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-emerald-600 dark:hover:bg-emerald-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
+                <a id="investments-btn" href="public/investimentos.html" target="_blank" class="bg-slate-500 text-white font-semibold py-2 px-4 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-slate-600 dark:bg-slate-600 dark:text-slate-200 dark:hover:bg-slate-500 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
                     <span>💹</span> <span>Investimentos</span>
                 </a>
-                <button id="manage-family-btn" class="bg-teal-500 text-white font-semibold py-2 px-3 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-teal-600 dark:hover:bg-teal-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
+                <button id="manage-family-btn" class="bg-slate-500 text-white font-semibold py-2 px-4 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-slate-600 dark:bg-slate-600 dark:text-slate-200 dark:hover:bg-slate-500 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
                      <span>&#128106;</span> <span>Família</span>
                 </button>
-                <button id="logout-btn" class="bg-rose-500 text-white font-semibold py-2 px-3 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-rose-600 dark:hover:bg-rose-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
+                <button id="logout-btn" class="bg-rose-500 text-white font-semibold py-2 px-4 rounded-lg shadow-sm dark:shadow-black/30 hover:bg-rose-600 dark:hover:bg-rose-400 transition-all duration-150 ease-in-out hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center gap-2 text-sm w-full sm:w-auto sm:flex-shrink-0">
                     <span>Sair</span>
                     <span class="text-xl">&#x23CF;</span> 
                 </button>
@@ -1465,10 +1465,10 @@
                     if(authInstance.currentUser) { 
                         const currentUserName = authInstance.currentUser.displayName || authInstance.currentUser.email || 'Usuário';
                         if(userGreetingEl) userGreetingEl.textContent = `Bem-vindo(a), ${currentUserName}!`;
-                        if(userInfoEl) {
-                            userInfoEl.textContent = `Logado como: ${authInstance.currentUser.email}`;
-                            userInfoEl.classList.remove('hidden');
-                        }
+                        // if(userInfoEl) {
+                        //     userInfoEl.textContent = `Logado como: ${authInstance.currentUser.email}`;
+                        //     userInfoEl.classList.remove('hidden');
+                        // }
                         if(logoutBtn) logoutBtn.classList.remove('hidden');
                     }
 


### PR DESCRIPTION
This commit addresses your feedback on the header UI:

- Standardizes header buttons ("Adicionar", "Investimentos", "Família") to a consistent gray background and padding.
- Ensures the "Sair" button remains red and shares the same padding for consistent sizing.
- Removes the "Logado como: <email>" message from the header, retaining only the "Bem-vindo(a)..." greeting.